### PR TITLE
Bump logback-classic from 0.9.30 to 1.2.0 in /sonar-plugins

### DIFF
--- a/sonar-plugins/pom.xml
+++ b/sonar-plugins/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>0.9.30</version>
+			<version>1.2.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Bumps logback-classic from 0.9.30 to 1.2.0.

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-classic dependency-type: direct:development ...